### PR TITLE
Fix reference for GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ At this point, executing `git commit` will trigger the `check-commit-msg` hook, 
 
 |if your commit|use this keyword|value|
 |-|-------|-----|
-|resolves an issue/ticket|resolves, res, resolved| !123(only for GitHub Issues), PROJ-1234|
-|only references an issue/ticket|ref, refs, references, refers to| !123(only for GitHub Issues), PROJ-1234|
+|resolves an issue/ticket|resolves, res, resolved| #123(only for GitHub Issues), PROJ-1234|
+|only references an issue/ticket|ref, refs, references, refers to| #123(only for GitHub Issues), PROJ-1234|
 
 *Example git commit message*:
 ```

--- a/commit-msg/check-commit-message
+++ b/commit-msg/check-commit-message
@@ -12,7 +12,7 @@ fi
 # The regex pattern
 # The (?i) is for case-insensitive matching
 # The \s* at the end is for optional trailing whitespace
-pattern='^(?i)(ref|refs|reference|references|res|resolve|resolves)\s*:\s*((#|gh-)\d+||[A-Za-z]+-\d+)\s*$'
+pattern='^(?i)(ref|refs|reference|references|res|resolve|resolves)\s*:\s*((#|gh-)\d+|[A-Za-z]+-\d+)\s*$'
 
 # Scan the entire file for lines matching the pattern
 if grep -Pq "$pattern" "$input_file"; then
@@ -35,16 +35,9 @@ else
   done while working on an issue, amend the commit to include
   a reference to the issue or ticket like so:
 
-<<<<<<< HEAD
   reference: PROJ-1234
   or
   reference: #123 (if referencing a GitHub issue)
-=======
-  ref: #123 // For GitHub issues
-  ref: PROJ-1234 // For other issue tracker IDs
-
-  See the contributing guidelines of this project for more details.
->>>>>>> cde242e (Fix reference for GitHub)
 
   Don't have a ticket to reference? You should create one.
   """

--- a/commit-msg/check-commit-message
+++ b/commit-msg/check-commit-message
@@ -12,7 +12,7 @@ fi
 # The regex pattern
 # The (?i) is for case-insensitive matching
 # The \s* at the end is for optional trailing whitespace
-pattern='^(?i)(ref|refs|reference|references|res|resolve|resolves)\s*:\s*(#\d+||[A-Za-z]+-\d+)\s*$'
+pattern='^(?i)(ref|refs|reference|references|res|resolve|resolves)\s*:\s*((#|gh-)\d+||[A-Za-z]+-\d+)\s*$'
 
 # Scan the entire file for lines matching the pattern
 if grep -Pq "$pattern" "$input_file"; then
@@ -35,9 +35,16 @@ else
   done while working on an issue, amend the commit to include
   a reference to the issue or ticket like so:
 
+<<<<<<< HEAD
   reference: PROJ-1234
   or
   reference: #123 (if referencing a GitHub issue)
+=======
+  ref: #123 // For GitHub issues
+  ref: PROJ-1234 // For other issue tracker IDs
+
+  See the contributing guidelines of this project for more details.
+>>>>>>> cde242e (Fix reference for GitHub)
 
   Don't have a ticket to reference? You should create one.
   """

--- a/commit-msg/check-commit-message
+++ b/commit-msg/check-commit-message
@@ -12,7 +12,7 @@ fi
 # The regex pattern
 # The (?i) is for case-insensitive matching
 # The \s* at the end is for optional trailing whitespace
-pattern="^(?i)(ref|refs|reference|references|res|resolve|resolves)[ \t]*:[ \t]*(gh-|\!|[A-Za-z]+-)\d+\s*$"
+pattern='^(?i)(ref|refs|reference|references|res|resolve|resolves)\s*:\s*(#\d+||[A-Za-z]+-\d+)\s*$'
 
 # Scan the entire file for lines matching the pattern
 if grep -Pq "$pattern" "$input_file"; then
@@ -24,13 +24,13 @@ else
 
   If this commit resolves an issue, add:
   
-  res: !123 # For GitHub issues
-  res: PROJ-1234 # For other issue tracker IDs
+  res: #123 // For GitHub issues
+  res: PROJ-1234 // For other issue tracker IDs
 
   If this commit is referencing an issue, but does not resolve it, add:
 
-  ref: !123 # For GitHub issues
-  ref: PROJ-1234 # For other issue tracker IDs
+  ref: #123 // For GitHub issues
+  ref: PROJ-1234 // For other issue tracker IDs
 
   See the contributing guidelines of this project for more details.
 


### PR DESCRIPTION
References on GitHub start with `#`[1].

[1] https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls