### PR TITLE
ADD support for all GitHub PR keywords

### DIFF
--- a/commit-msg/check-commit-message
+++ b/commit-msg/check-commit-message
@@ -12,7 +12,7 @@ fi
 # The regex pattern
 # The (?i) is for case-insensitive matching
 # The \s* at the end is for optional trailing whitespace
-pattern='^(?i)(ref|refs|reference|references|res|resolve|resolves)\s*:\s*((#|gh-)\d+|[A-Za-z]+-\d+)\s*$'
+pattern='^(?i)(ref|refs|reference|references|res|resolve|resolves|resolved|close|closes|closed|fix|fixes|fixed)\s*:\s*((#|gh-)\d+|[A-Za-z]+-\d+)\s*$'
 
 # Scan the entire file for lines matching the pattern
 if grep -Pq "$pattern" "$input_file"; then


### PR DESCRIPTION
This commit ensures support for all keywords used in GitHub pull requests. The list of words can be viewed at [1]

Resolves: EC-185

[1]
https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests